### PR TITLE
Filter empty request paths for new URLS

### DIFF
--- a/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryUrlCommand.php
+++ b/Iazel/RegenProductUrl/Console/Command/RegenerateCategoryUrlCommand.php
@@ -126,6 +126,7 @@ class RegenerateCategoryUrlCommand extends Command
 
             $newUrls = $this->categoryUrlRewriteGenerator->generate($category);
             try {
+                $newUrls = $this->filterEmptyRequestPaths($newUrls);
                 $this->urlPersist->replace($newUrls);
                 $regenerated += count($newUrls);
             }
@@ -136,4 +137,22 @@ class RegenerateCategoryUrlCommand extends Command
         $this->emulation->stopEnvironmentEmulation();
         $out->writeln('Done regenerating. Regenerated ' . $regenerated . ' urls');
     }
+    
+    /**
+     * Remove entries with request_path='' to prevent error 404 for "http://site.com/" address.
+     *
+     * @param \Magento\UrlRewrite\Service\V1\Data\UrlRewrite[] $newUrls
+     * @return \Magento\UrlRewrite\Service\V1\Data\UrlRewrite[]
+     */
+    private function filterEmptyRequestPaths($newUrls)
+    {
+        $result = [];
+        foreach ($newUrls as $key => $url) {
+            $requestPath = $url->getRequestPath();
+            if (!empty($requestPath)) {
+                $result[$key] = $url;
+            }
+        }
+        return $result;
+    }    
 }


### PR DESCRIPTION
Remove entries with request_path='' to prevent error 404 for "http://site.com/" address.

I don't know how, but I have entries with empty `request_path` for root categories after regeneration:

![image](https://user-images.githubusercontent.com/5052385/44895746-6589cb00-acfe-11e8-971b-1bdfcdd6caeb.png)

Then I have 404 page for the home URL :(

This filter prevents creation entries with empty `request_path` for root  categories.